### PR TITLE
Fix broken blog post URLs for SEO

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ const currentPath = Astro.url.pathname;
 
 const navItems = [
   { href: '/', label: 'Home' },
-  { href: '/blog', label: 'Blog' },
+  { href: '/posts', label: 'Blog' },
   { href: '/tags', label: 'Tags' },
   { href: '/about', label: 'About' },
 ];

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -6,10 +6,10 @@ const recentPosts = await getRecentPosts();
 const currentPath = Astro.url.pathname;
 
 // 현재 카테고리 확인
-const currentCategory = currentPath.includes('/blog/category/')
-  ? currentPath.split('/blog/category/')[1]?.replace('/', '')
-  : currentPath.includes('/blog/')
-  ? currentPath.split('/blog/')[1]?.split('/')[0]
+const currentCategory = currentPath.includes('/category/')
+  ? currentPath.split('/category/')[1]?.replace('/', '')
+  : currentPath !== '/' && currentPath !== '/posts' && !currentPath.startsWith('/posts/') && !currentPath.startsWith('/tags')
+  ? currentPath.split('/')[1]?.split('/')[0]
   : null;
 ---
 
@@ -45,7 +45,7 @@ const currentCategory = currentPath.includes('/blog/category/')
         {recentPosts.map(post => (
           <li>
             <a
-              href={`/blog/${post.slug}`}
+              href={`/${post.slug}`}
               class="recent-post-link"
             >
               <span class="post-title">{post.title}</span>

--- a/src/components/ui/blog-post-card.tsx
+++ b/src/components/ui/blog-post-card.tsx
@@ -27,7 +27,7 @@ export function BlogPostCard({
 }: BlogPostCardProps) {
   return (
     <Card className={cn("group hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 hover:border-primary/50", className)}>
-      <a href={`/blog/${slug}`} className="block">
+      <a href={`/${slug}`} className="block">
         <CardHeader>
           <div className="flex items-start justify-between gap-2 mb-2">
             {categories.length > 0 && (

--- a/src/components/ui/blog-sidebar.tsx
+++ b/src/components/ui/blog-sidebar.tsx
@@ -197,7 +197,7 @@ export function BlogSidebar({ recentPosts, categoryGroups, currentCategory }: Bl
                     {recentPosts.map((post) => (
                       <a
                         key={post.slug}
-                        href={`/blog/${post.slug}`}
+                        href={`/${post.slug}`}
                         className="block p-2 rounded-md hover:bg-accent transition-colors"
                       >
                         <div className="text-sm font-medium line-clamp-2 mb-1">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -34,7 +34,7 @@ const recentPosts = allPosts
             홈으로 돌아가기
           </Button>
         </a>
-        <a href="/blog">
+        <a href="/posts">
           <Button variant="outline" size="lg" className="blog-button">
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" class="mr-2">
               <path d="M4 4H16V6H4V4ZM4 8H16V10H4V8ZM4 12H12V14H4V12Z" fill="currentColor"/>
@@ -51,7 +51,7 @@ const recentPosts = allPosts
           <ul class="recent-posts-list">
             {recentPosts.map((post) => (
               <li class="recent-post-item">
-                <a href={`/blog/${post.id}`} class="recent-post-link">
+                <a href={`/${post.id}`} class="recent-post-link">
                   {post.data.categories && post.data.categories.length > 0 && (
                     <div class="post-category">
                       {post.data.categories[0]}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -2,12 +2,12 @@
 /**
  * Dynamic Blog Post Route
  *
- * URL 구조: /experimental/blog/{category}/{slug}
- * 예: /experimental/blog/javascript/nestjs-dematerializer-1
+ * URL 구조: /{category}/{slug}
+ * 예: /javascript/nestjs-dematerializer-1
  *
- * Jekyll 호환 URL 패턴 유지:
+ * Jekyll 호환 URL 패턴:
  * - Jekyll: /{category}/{slug}/
- * - Astro: /experimental/blog/{category}/{slug}
+ * - Astro: /{category}/{slug}
  */
 
 import { getCollection, type CollectionEntry, render } from 'astro:content';

--- a/src/pages/category/[category].astro
+++ b/src/pages/category/[category].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
 import { BlogPostCard } from '@/components/ui/blog-post-card';
 import { calculateReadingTime } from '@/utils/readingTime';
 import { Layers, Clock, Monitor, Code, Brain, Box, Palette, DollarSign, HardDrive, Terminal, FileCode, BookOpen, Globe, Folder } from 'lucide-react';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,7 +40,7 @@ const posts = allPosts
           최근 포스트
         </h2>
         <Button variant="outline" asChild client:load>
-          <a href="/blog">
+          <a href="/posts">
             전체 보기 →
           </a>
         </Button>

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -3,9 +3,9 @@
  * Blog List with Pagination
  *
  * URL 구조:
- * - /blog → 첫 페이지
- * - /blog/2 → 두 번째 페이지
- * - /blog/3 → 세 번째 페이지
+ * - /posts → 첫 페이지
+ * - /posts/2 → 두 번째 페이지
+ * - /posts/3 → 세 번째 페이지
  */
 
 import { getCollection } from 'astro:content';
@@ -72,7 +72,7 @@ const description = "Tolerblanc의 기술 블로그 포스트 목록";
     <BlogPagination
       currentPage={currentPage}
       totalPages={lastPage}
-      baseUrl="/blog"
+      baseUrl="/posts"
       client:load
     />
   </div>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -32,7 +32,7 @@ export async function GET(context: APIContext) {
       title: post.data.title,
       pubDate: new Date(post.data.date),
       description: post.data.description || post.data.excerpt,
-      link: `/blog/${post.data.categories.map(c => c.toLowerCase()).join('-')}-${post.id.split('/').pop()?.replace('.mdx', '')}/`,
+      link: `/${post.id}`,
       categories: post.data.categories,
     })),
     customData: `<language>ko</language>`,

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -62,7 +62,7 @@ export async function getNavigationCategories(): Promise<NavCategory[]> {
       return {
         id,
         name,
-        path: `${SITE_CONFIG.BASE_PATH}/blog/category/${id}`,
+        path: `${SITE_CONFIG.BASE_PATH}/category/${id}`,
         postCount: count,
       };
     })


### PR DESCRIPTION
BREAKING CHANGE: URL structure has changed to remove /blog prefix

- Individual posts: /{category}/{slug} (was: /blog/{category}/{slug})
- Category pages: /category/{category} (was: /blog/category/{category})
- Posts listing: /posts (was: /blog)

Changes:
- Moved src/pages/blog/[...slug].astro -> src/pages/[...slug].astro
- Moved src/pages/blog/category/[category].astro -> src/pages/category/[category].astro
- Moved src/pages/blog/[...page].astro -> src/pages/posts/[...page].astro
- Updated all internal links in components and pages
- Fixed RSS feed URLs
- Updated navigation utilities

This restores the original Jekyll-compatible URL structure and fixes SEO issues.