### PR TITLE
fix: pagination url path mismatch

### DIFF
--- a/src/components/ui/blog-pagination.tsx
+++ b/src/components/ui/blog-pagination.tsx
@@ -62,7 +62,7 @@ export function BlogPagination({
     if (page === 1) {
       return baseUrl
     }
-    return `${baseUrl}/page/${page}`
+    return `${baseUrl}/${page}`
   }
 
   if (totalPages <= 1) {

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -30,7 +30,7 @@ type Props = {
 };
 
 const { page } = Astro.props;
-const { data: posts, currentPage, lastPage, url } = page;
+const { data: posts, currentPage, lastPage } = page;
 
 const title = currentPage === 1
   ? "블로그 - Tolerblanc's Blog"


### PR DESCRIPTION
Corrects the pagination URL generation to match the Astro route structure (removing '/page' segment). Also removes unused variable in posts page.